### PR TITLE
build(ci): change workflow and trigger events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: 'Mirroring workflow'
+name: 'CI'
 on:
   push:
   workflow_dispatch:


### PR DESCRIPTION
Update the name of the workflow from "Mirroring workflow" to "CI". Also, modify the trigger events to include both push and workflow_dispatch. This change workflow is triggered correctly.